### PR TITLE
Remove tools:ignore="GradleOverrides" in order to use tools:overrideLibrary marker

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -5,8 +5,7 @@
 
     <uses-sdk
         android:minSdkVersion="8"
-        android:targetSdkVersion="19"
-        tools:ignore="GradleOverrides" />
+        android:targetSdkVersion="19"/>
 
     <application />
 


### PR DESCRIPTION
Current nga app `minSdkVersion` is 14, when we want to import a third-party library with minSdkVersion higher than 14, we need to declare `tools:overrideLibrary` marker in Manifest to select which libraries can be imported ignoring the `minSdkVesrion`.

However `tools:ignore="GradleOverrides"` leads to Manifest merger failed.

see [tools:overrideLibrary-marker](http://tools.android.com/tech-docs/new-build-system/user-guide/manifest-merger#TOC-tools:overrideLibrary-marker) and [android-gradle-manifest-merger-failed](http://www.we-edit.de/stackoverflow/question/android-gradle-manifest-merger-failed-31062893.html)
